### PR TITLE
doc: Adds a @shortdoc to Mix.Tasks.Fact.Create

### DIFF
--- a/lib/mix/tasks/fact/create.ex
+++ b/lib/mix/tasks/fact/create.ex
@@ -95,6 +95,8 @@ defmodule Mix.Tasks.Fact.Create do
 
   use Mix.Task
 
+  @shortdoc "Creates a Fact database"
+
   alias Fact.Genesis.Command.CreateDatabase
   alias Fact.Genesis.TheCreator
   alias Fact.Genesis.Decider


### PR DESCRIPTION
So that `fact.create` show up when you run `mix help`.