### PR TITLE
chore: Added badges for version, docs and downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 [![Test](https://github.com/evntd/fact/actions/workflows/elixir.yml/badge.svg)](https://github.com/evntd/fact/actions/workflows/elixir.yml)
+[![fact version](https://img.shields.io/hexpm/v/fact.svg)](https://hex.pm/packages/fact)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/fact/)
+[![Hex.pm](https://img.shields.io/hexpm/dt/fact.svg)](https://hex.pm/packages/)
 
 <div style="display: flex; justify-content: center;">
   <img alt="logo" src=".github/assets/logo.png" width="424">


### PR DESCRIPTION
This PR adds a set of badges to the top of the `README.md` file. These badges provide immediate visual feedback on the project's version, link to hex docs and number of downloads, improving the professional look and informational clarity of the repository.