### PR TITLE
fix: use short-circuit, remove use from_none query 

### DIFF
--- a/lib/fact/event_ledger.ex
+++ b/lib/fact/event_ledger.ex
@@ -65,7 +65,7 @@ defmodule Fact.EventLedger do
 
   Each event is enriched with additional metadata, including a timestamp, and assigning a store position.
   Events are then written to the configured storage and a reference to the event is appended to the ledger file.
-  
+
   If the commit operation is successful, an `{:appended, {record_id, event}}` message will be published by the 
   `Fact.EventPublisher` for each event that was written.
   """


### PR DESCRIPTION
The from_none query produces a predicate function that always returns false, and then scans the entire ledger, always returning an empty stream. Replaces it with a overload of check_query_condition that just short circuits the ledger scan, because it will always succeed.