### PR TITLE
chore: only trigger pushes directly to main

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -3,6 +3,8 @@ name: Build & Test
 on:
   pull_request:
   push:
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
Forgot about this when I split build/test from publish.  Which resulted in 14 actions running on each pull request, which was just a waste of electricity.