### PR TITLE
Feature: Backup

### DIFF
--- a/lib/mix/tasks/fact/backup.ex
+++ b/lib/mix/tasks/fact/backup.ex
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Fact.Backup do
         ]
       )
 
-    path   = fetch_required!(parsed, :path)
+    path = fetch_required!(parsed, :path)
     output = fetch_required!(parsed, :output)
     include_indices = Keyword.get(parsed, :include_indices, false)
 


### PR DESCRIPTION
Introduces a new Mix task `mix fact.backup` for generating backup archives of a Fact database directory. The task supports:

- --path: required input directory for the Fact database
- --output: required output path (file or directory)
- Auto-naming ZIP files when --output is a directory, using:
    <basename>_YYYYMMDD_HHMMSS.zip
- Optional inclusion of the indices directory via --include-indices
- Packaging of core database files (.bootstrap, .gitignore, .ledger)
- Recursive inclusion of events/ and optionally indices/
- Creation of ZIP archives in memory using :zip